### PR TITLE
Dev

### DIFF
--- a/cms-workflow.php
+++ b/cms-workflow.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name:        CMS-Workflow
 Plugin URI:         https://github.com/RRZE-Webteam/cms-workflow
-Version:            2.0.5
+Version:            2.0.6
 Description:        Redaktioneller Workflow.
 Author:             RRZE-Webteam
 Author URI:         https://blogs.fau.de/webworking/

--- a/includes/Modules/Authors/Authors.php
+++ b/includes/Modules/Authors/Authors.php
@@ -606,6 +606,11 @@ class Authors extends Module
         $user_id = isset($args[1]) ? $args[1] : 0;
         $post_id = isset($args[2]) ? $args[2] : 0;
 
+        // Damn workaround for the block editor!
+        if (is_a($post_id, 'WP_Block_Editor_Context')) {
+            $post_id = $post_id->post->ID;
+        }
+
         if ($revision_parent_id = wp_is_post_revision($post_id)) {
             $post_id = $revision_parent_id;
         }

--- a/includes/Modules/Authors/Authors.php
+++ b/includes/Modules/Authors/Authors.php
@@ -606,15 +606,6 @@ class Authors extends Module
         $user_id = isset($args[1]) ? $args[1] : 0;
         $post_id = isset($args[2]) ? $args[2] : 0;
 
-        // Damn workaround for the block editor!
-        if (is_a($post_id, 'WP_Block_Editor_Context')) {
-            $post_id = $post_id->post->ID;
-        }
-
-        if (absint($post_id) == 0) {
-            return $allcaps;
-        }
-
         if ($revision_parent_id = wp_is_post_revision($post_id)) {
             $post_id = $revision_parent_id;
         }


### PR DESCRIPTION
- Removes the old blockeditor workaround and the check absint($post_id)==0, because the function always returned in the first if condition using the classic editor, making editing the own  site impossible.

- Testsed in Local DEV environment: worked